### PR TITLE
Add GitHub Actions for the plugin check

### DIFF
--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,36 @@
+name: Plugin Check
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+  release:
+    types: [ published ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Composer install
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: latest
+          coverage: none
+          tools: wp-cli
+
+      - name: Install latest version of dist-archive-command
+        run: wp package install wp-cli/dist-archive-command:@stable
+
+      - name: Build plugin
+        run: |
+          wp dist-archive . ./${{ github.event.repository.name }}.zip
+          mkdir tmp-build
+          unzip ${{ github.event.repository.name }}.zip -d tmp-build
+
+      - name: Run plugin check
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: ./tmp-build/${{ github.event.repository.name }}


### PR DESCRIPTION
Add a workflow that runs the WordPress Plugin Check for pull requests on the `develop` branch and on releases.