### PR TITLE
Update query logic

### DIFF
--- a/lib/PostMeta/WebsiteData.php
+++ b/lib/PostMeta/WebsiteData.php
@@ -20,6 +20,7 @@ class WebsiteData {
 	 */
 	public function init() {
 		add_action( 'init', [ $this, 'register_post_meta' ] );
+		add_action( 'save_post', [ $this, 'save_sanitized_url_meta' ], 99, 2 );
 	}
 
 	/**
@@ -38,5 +39,84 @@ class WebsiteData {
 				'sanitize_callback' => 'sanitize_url',
 			]
 		);
+	}
+
+	/**
+	 * Saves sanitized URL meta for webring websites.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 *
+	 * @return void
+	 */
+	public function save_sanitized_url_meta( $post_id, $post ) {
+		if ( 'webring_website' !== $post->post_type ) {
+			return;
+		}
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$url = get_post_meta( $post_id, 'webring_website_url', true );
+
+		if ( '' === $url ) {
+			delete_post_meta( $post_id, '_webring_website_url_sanitized' );
+
+			return;
+		}
+
+		$sanitized = $this->normalize_url( $url );
+
+		if ( '' === $sanitized ) {
+			delete_post_meta( $post_id, '_webring_website_url_sanitized' );
+
+			return;
+		}
+
+		update_post_meta( $post_id, '_webring_website_url_sanitized', $sanitized );
+	}
+
+	/**
+	 * Normalizes a URL by trimming it and handling bare domains.
+	 *
+	 * @param string $url The URL to normalize.
+	 *
+	 * @return string The normalized URL.
+	 */
+	public function normalize_url( $url ): string {
+		$url = trim( (string) $url );
+
+		if ( '' === $url ) {
+			return '';
+		}
+
+		// Accept bare domains too.
+		if ( ! preg_match( '#^[a-z][a-z0-9+\-.]*://#i', $url ) ) {
+			$url = 'https://' . $url;
+		}
+
+		$parts = wp_parse_url( $url );
+
+		if ( empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$host = strtolower( $parts['host'] );
+		$path = '';
+
+		if ( ! empty( $parts['path'] ) && '/' !== $parts['path'] ) {
+			$path = untrailingslashit( $parts['path'] );
+		}
+
+		return $host . $path;
 	}
 }

--- a/lib/Rewrite/Redirect.php
+++ b/lib/Rewrite/Redirect.php
@@ -57,7 +57,7 @@ class Redirect {
 	}
 
 	/**
-	 * Retrieves the URL of the next, previous or random site in a webring.
+	 * Retrieves the URL of the next, previous, or random site in a webring.
 	 *
 	 * @param string      $action   The action to perform: 'next', 'prev' or 'random'.
 	 * @param string      $url      The current site's domain.
@@ -66,213 +66,200 @@ class Redirect {
 	 * @return string The URL of the new site in the webring, or an empty string if no site is found.
 	 */
 	public function get_new_webring_site( string $action, string $url, string $category = null ): string {
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
 		$current_site = $this->get_site_by_domain( $url );
 		if ( ! $current_site ) {
 			wp_die( 'Webring site not found', 'Webring', 404 );
 		}
 
+		$current_site_url_sanitized = get_post_meta( $current_site->ID, '_webring_website_url_sanitized', true );
+
 		global $wpdb;
 
+		$term_tax_id = null;
 		if ( $category ) {
 			$term = get_term_by( 'slug', $category, 'webring_category' );
 			if ( ! $term ) {
 				return '';
 			}
-
-			$term_tax_id = $term->term_taxonomy_id;
-
-			if ( 'prev' === $action ) {
-				$where_clause = '
-					  AND p.menu_order <= %d
-					  AND p.post_date <= %s
-				';
-				$order_clause = 'ORDER BY tr.term_order DESC, p.menu_order DESC, p.post_date DESC, p.ID DESC';
-			} elseif ( 'next' === $action ) {
-				$where_clause = '
-					  AND p.menu_order >= %d
-					  AND p.post_date >= %s
-				';
-				$order_clause = 'ORDER BY tr.term_order ASC, p.menu_order ASC, p.post_date ASC, p.ID ASC';
-			} else {
-				$where_clause = '
-					  -- ignoring menu_order %d
-					  -- ignoring post_date %s
-				';
-				$order_clause = 'ORDER BY RAND()';
-			}
-
-			// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter
-			$sites = $wpdb->get_col(
-				$wpdb->prepare(
-					"
-					SELECT p.ID
-					FROM {$wpdb->posts} p
-					INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
-					INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
-					WHERE p.post_type = 'webring_website'
-					  AND p.post_status = 'publish'
-					  AND tr.term_taxonomy_id = %d
-					  AND pm.meta_key = '_webring_website_url_sanitized'
-					  AND pm.meta_value != %s
-					  {$where_clause}
-					{$order_clause}
-					LIMIT 1
-					",
-					$term_tax_id,
-					$current_site->post_title,
-					$current_site->menu_order,
-					$current_site->post_date
-				)
-			);
-			// If no site was found, we might hit the beginning or end of the webring.
-			if ( empty( $sites ) ) {
-				if ( 'prev' === $action ) {
-					$sites = $wpdb->get_col(
-						$wpdb->prepare(
-							"
-							SELECT p.ID
-							FROM {$wpdb->posts} p
-							INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
-							INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
-							WHERE p.post_type = 'webring_website'
-							  AND p.post_status = 'publish'
-							  AND tr.term_taxonomy_id = %d
-							  AND pm.meta_key = '_webring_website_url_sanitized'
-							  AND pm.meta_value != %s
-							ORDER BY tr.term_order DESC, p.menu_order DESC, p.post_date DESC, p.ID DESC
-							LIMIT 1
-							",
-							$term_tax_id,
-							$current_site->post_title
-						)
-					);
-				} elseif ( 'next' === $action ) {
-					$sites = $wpdb->get_col(
-						$wpdb->prepare(
-							"
-							SELECT p.ID
-							FROM {$wpdb->posts} p
-							INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
-							INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
-							WHERE p.post_type = 'webring_website'
-							  AND p.post_status = 'publish'
-							  AND tr.term_taxonomy_id = %d
-							  AND pm.meta_key = '_webring_website_url_sanitized'
-							  AND pm.meta_value != %s
-							ORDER BY tr.term_order ASC, p.menu_order ASC, p.post_date ASC, p.ID ASC
-							LIMIT 1
-							",
-							$term_tax_id,
-							$current_site->post_title
-						)
-					);
-				}
-			}
-		} else {
-			if ( 'prev' === $action ) {
-				$where_clause = '
-					  AND p.menu_order <= %d
-					  AND p.post_date <= %s
-				';
-				$order_clause = 'ORDER BY p.menu_order DESC, p.post_date DESC, p.ID DESC';
-			} elseif ( 'next' === $action ) {
-				$where_clause = '
-					  AND p.menu_order >= %d
-					  AND p.post_date >= %s
-				';
-				$order_clause = 'ORDER BY p.menu_order ASC, p.post_date ASC, p.ID ASC';
-			} else {
-				$where_clause = '
-					  -- ignoring menu_order %d
-					  -- ignoring post_date %s
-				';
-				$order_clause = 'ORDER BY RAND()';
-			}
-
-			// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter
-			$sites = $wpdb->get_col(
-				$wpdb->prepare(
-					"
-					SELECT p.ID
-					FROM {$wpdb->posts} p
-					INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
-					WHERE p.post_type = 'webring_website'
-					  AND p.post_status = 'publish'
-					  AND pm.meta_key = '_webring_website_url_sanitized'
-					  AND pm.meta_value != %s
-					  {$where_clause}
-					{$order_clause}
-					LIMIT 1
-					",
-					$current_site->post_title,
-					$current_site->menu_order,
-					$current_site->post_date
-				)
-			);
-
-			// If no site was found, we might hit the beginning or end of the webring.
-			if ( empty( $sites ) ) {
-				if ( 'prev' === $action ) {
-					$sites = $wpdb->get_col(
-						$wpdb->prepare(
-							"
-							SELECT p.ID
-							FROM {$wpdb->posts} p
-							INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
-							WHERE p.post_type = 'webring_website'
-							  AND p.post_status = 'publish'
-							  AND pm.meta_key = '_webring_website_url_sanitized'
-							  AND pm.meta_value != %s
-							ORDER BY p.menu_order DESC, p.post_date DESC, p.ID DESC
-							LIMIT 1
-							",
-							$current_site->post_title
-						)
-					);
-				} elseif ( 'next' === $action ) {
-					$sites = $wpdb->get_col(
-						$wpdb->prepare(
-							"
-							SELECT p.ID
-							FROM {$wpdb->posts} p
-							INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
-							WHERE p.post_type = 'webring_website'
-							  AND p.post_status = 'publish'
-							  AND pm.meta_key = '_webring_website_url_sanitized'
-							  AND pm.meta_value != %s
-							ORDER BY p.menu_order ASC, p.post_date ASC, p.ID ASC
-							LIMIT 1
-							",
-							$current_site->post_title
-						)
-					);
-				}
-			}
-
-			if ( empty( $sites ) ) {
-				return '';
-			}
+			$term_tax_id = (int) $term->term_taxonomy_id;
 		}
+
+		$sites = $this->query_candidate_sites(
+			$action,
+			$current_site,
+			$current_site_url_sanitized,
+			$term_tax_id
+		);
 
 		if ( empty( $sites ) ) {
 			return '';
 		}
 
-		// Get domain from post_title (adjust if using post_name or custom field).
 		$url = trim( get_post_meta( $sites[0], 'webring_website_url', true ) );
 		if ( ! $url ) {
 			return '';
 		}
 
-		// Ensure full URL.
 		if ( ! preg_match( '#^https?://#', $url ) ) {
 			$url = 'https://' . $url;
 		}
 
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		return esc_url_raw( $url );
+	}
+
+	/**
+	 * Builds and executes the query for candidate site IDs.
+	 *
+	 * @param string   $action                     The navigation action.
+	 * @param object   $current_site               The current site object.
+	 * @param string   $current_site_url_sanitized The sanitized current site URL.
+	 * @param int|null $term_tax_id                Optional term taxonomy ID when filtering by category.
+	 *
+	 * @return array<int> List of matching post IDs.
+	 */
+	private function query_candidate_sites( string $action, object $current_site, string $current_site_url_sanitized, ?int $term_tax_id = null ): array {
+		$clause_info = $this->get_navigation_clauses( $action, $current_site );
+
+		if ( null === $clause_info ) {
+			return [];
+		}
+
+		$main_sites = $this->run_candidate_query(
+			$current_site_url_sanitized,
+			$clause_info['where_clause'],
+			$term_tax_id ? $clause_info['term_order_clause'] : $clause_info['order_clause'],
+			$term_tax_id
+		);
+
+		if ( ! empty( $main_sites ) || 'random' === $action ) {
+			return $main_sites;
+		}
+
+		if ( 'prev' !== $action && 'next' !== $action ) {
+			return [];
+		}
+
+		return $this->run_candidate_query(
+			$current_site_url_sanitized,
+			'',
+			$term_tax_id ? $clause_info['term_order_clause'] : $clause_info['order_clause'],
+			$term_tax_id
+		);
+	}
+
+	/**
+	 * Returns SQL clause data for the requested navigation action.
+	 *
+	 * @param string $action       The navigation action.
+	 * @param object $current_site Current site object.
+	 *
+	 * @return array<string, string>|null
+	 */
+	private function get_navigation_clauses( string $action, object $current_site ): ?array {
+		if ( 'prev' === $action ) {
+			return [
+				'where_clause'      => $this->build_boundary_clause( '<=', $current_site ),
+				'order_clause'      => 'ORDER BY p.menu_order DESC, p.post_date DESC, p.ID DESC',
+				'term_order_clause' => 'ORDER BY tr.term_order DESC, p.menu_order DESC, p.post_date DESC, p.ID DESC',
+			];
+		}
+
+		if ( 'next' === $action ) {
+			return [
+				'where_clause'      => $this->build_boundary_clause( '>=', $current_site ),
+				'order_clause'      => 'ORDER BY p.menu_order ASC, p.post_date ASC, p.ID ASC',
+				'term_order_clause' => 'ORDER BY tr.term_order ASC, p.menu_order ASC, p.post_date ASC, p.ID ASC',
+			];
+		}
+
+		if ( 'random' === $action ) {
+			return [
+				'where_clause'      => '',
+				'order_clause'      => 'ORDER BY RAND()',
+				'term_order_clause' => 'ORDER BY RAND()',
+			];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Builds the boundary clause for prev/next navigation.
+	 *
+	 * @param string $operator     Comparison operator.
+	 * @param object $current_site Current site object.
+	 *
+	 * @return string
+	 */
+	private function build_boundary_clause( string $operator, object $current_site ): string {
+		global $wpdb;
+
+		if ( ! in_array( $operator, [ '>=', '<=' ], true ) ) {
+			return '';
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		return $wpdb->prepare(
+			'AND p.menu_order ' . $operator . ' %d AND p.post_date ' . $operator . ' %s ',
+			$current_site->menu_order,
+			$current_site->post_date
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Executes the candidate site query.
+	 *
+	 * @param string   $current_site_url_sanitized The sanitized current site URL.
+	 * @param string   $where_clause               Optional WHERE fragment.
+	 * @param string   $order_clause               ORDER BY fragment.
+	 * @param int|null $term_tax_id                Optional term taxonomy ID.
+	 *
+	 * @return array<int>
+	 */
+	private function run_candidate_query( string $current_site_url_sanitized, string $where_clause, string $order_clause, ?int $term_tax_id = null ): array {
+		global $wpdb;
+
+		$sql = "
+			SELECT p.ID
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
+		";
+
+		if ( $term_tax_id ) {
+			$sql .= $wpdb->prepare(
+				"
+				INNER JOIN {$wpdb->term_relationships} tr ON (
+					p.ID = tr.object_id
+					AND tr.term_taxonomy_id = %d
+				)
+				",
+				$term_tax_id
+			);
+		}
+
+		$sql .= "
+			WHERE p.post_type = 'webring_website'
+			  AND p.post_status = 'publish'
+		";
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql .= $wpdb->prepare(
+			"
+			  AND pm.meta_key = '_webring_website_url_sanitized'
+			  AND pm.meta_value != %s
+			  {$where_clause}
+			{$order_clause}
+			LIMIT 1
+			",
+			$current_site_url_sanitized
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		// phpcs:ignore WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery, PluginCheck.Security.DirectDB
+		return $wpdb->get_col( $sql );
 	}
 
 	/**

--- a/lib/Rewrite/Redirect.php
+++ b/lib/Rewrite/Redirect.php
@@ -60,14 +60,14 @@ class Redirect {
 	 * Retrieves the URL of the next, previous or random site in a webring.
 	 *
 	 * @param string      $action   The action to perform: 'next', 'prev' or 'random'.
-	 * @param string      $domain   The current site's domain.
+	 * @param string      $url      The current site's domain.
 	 * @param string|null $category Optional. The category slug to filter sites by. Default null.
 	 *
 	 * @return string The URL of the new site in the webring, or an empty string if no site is found.
 	 */
-	public function get_new_webring_site( string $action, string $domain, string $category = null ): string {
+	public function get_new_webring_site( string $action, string $url, string $category = null ): string {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$current_site = $this->get_site_by_domain( $domain );
+		$current_site = $this->get_site_by_domain( $url );
 		if ( ! $current_site ) {
 			wp_die( 'Webring site not found', 'Webring', 404 );
 		}
@@ -102,16 +102,19 @@ class Redirect {
 				$order_clause = 'ORDER BY RAND()';
 			}
 
+			// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter
 			$sites = $wpdb->get_col(
 				$wpdb->prepare(
 					"
 					SELECT p.ID
 					FROM {$wpdb->posts} p
+					INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
 					INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
 					WHERE p.post_type = 'webring_website'
 					  AND p.post_status = 'publish'
 					  AND tr.term_taxonomy_id = %d
-					  AND p.post_title != %s
+					  AND pm.meta_key = '_webring_website_url_sanitized'
+					  AND pm.meta_value != %s
 					  {$where_clause}
 					{$order_clause}
 					LIMIT 1
@@ -130,11 +133,13 @@ class Redirect {
 							"
 							SELECT p.ID
 							FROM {$wpdb->posts} p
+							INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
 							INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
 							WHERE p.post_type = 'webring_website'
 							  AND p.post_status = 'publish'
 							  AND tr.term_taxonomy_id = %d
-							  AND p.post_title != %s
+							  AND pm.meta_key = '_webring_website_url_sanitized'
+							  AND pm.meta_value != %s
 							ORDER BY tr.term_order DESC, p.menu_order DESC, p.post_date DESC, p.ID DESC
 							LIMIT 1
 							",
@@ -148,11 +153,13 @@ class Redirect {
 							"
 							SELECT p.ID
 							FROM {$wpdb->posts} p
+							INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
 							INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
 							WHERE p.post_type = 'webring_website'
 							  AND p.post_status = 'publish'
 							  AND tr.term_taxonomy_id = %d
-							  AND p.post_title != %s
+							  AND pm.meta_key = '_webring_website_url_sanitized'
+							  AND pm.meta_value != %s
 							ORDER BY tr.term_order ASC, p.menu_order ASC, p.post_date ASC, p.ID ASC
 							LIMIT 1
 							",
@@ -183,14 +190,17 @@ class Redirect {
 				$order_clause = 'ORDER BY RAND()';
 			}
 
+			// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter
 			$sites = $wpdb->get_col(
 				$wpdb->prepare(
 					"
 					SELECT p.ID
 					FROM {$wpdb->posts} p
+					INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
 					WHERE p.post_type = 'webring_website'
 					  AND p.post_status = 'publish'
-					  AND p.post_title != %s
+					  AND pm.meta_key = '_webring_website_url_sanitized'
+					  AND pm.meta_value != %s
 					  {$where_clause}
 					{$order_clause}
 					LIMIT 1
@@ -209,9 +219,11 @@ class Redirect {
 							"
 							SELECT p.ID
 							FROM {$wpdb->posts} p
+							INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
 							WHERE p.post_type = 'webring_website'
 							  AND p.post_status = 'publish'
-							  AND p.post_title != %s
+							  AND pm.meta_key = '_webring_website_url_sanitized'
+							  AND pm.meta_value != %s
 							ORDER BY p.menu_order DESC, p.post_date DESC, p.ID DESC
 							LIMIT 1
 							",
@@ -224,9 +236,11 @@ class Redirect {
 							"
 							SELECT p.ID
 							FROM {$wpdb->posts} p
+							INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
 							WHERE p.post_type = 'webring_website'
 							  AND p.post_status = 'publish'
-							  AND p.post_title != %s
+							  AND pm.meta_key = '_webring_website_url_sanitized'
+							  AND pm.meta_value != %s
 							ORDER BY p.menu_order ASC, p.post_date ASC, p.ID ASC
 							LIMIT 1
 							",
@@ -246,19 +260,19 @@ class Redirect {
 		}
 
 		// Get domain from post_title (adjust if using post_name or custom field).
-		$domain = trim( get_post_field( 'post_title', $sites[0] ) );
-		if ( ! $domain ) {
+		$url = trim( get_post_meta( $sites[0], 'webring_website_url', true ) );
+		if ( ! $url ) {
 			return '';
 		}
 
 		// Ensure full URL.
-		if ( ! preg_match( '#^https?://#', $domain ) ) {
-			$domain = 'https://' . $domain;
+		if ( ! preg_match( '#^https?://#', $url ) ) {
+			$url = 'https://' . $url;
 		}
 
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-		return esc_url_raw( $domain );
+		return esc_url_raw( $url );
 	}
 
 	/**
@@ -283,9 +297,11 @@ class Redirect {
 				"
 				SELECT p.*
 				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
 				WHERE p.post_type = 'webring_website'
 				  AND p.post_status = 'publish'
-				  AND p.post_title = %s
+				  AND pm.meta_key = '_webring_website_url_sanitized'
+				  AND pm.meta_value = %s
 				",
 				$domain
 			)

--- a/src/block/website-list/render.php
+++ b/src/block/website-list/render.php
@@ -21,6 +21,7 @@ $args = [
 ];
 
 if ( ! empty( $attributes['categories'] ) ) {
+	// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 	$args['tax_query'] = [
 		[
 			'taxonomy' => 'webring_category',
@@ -125,4 +126,5 @@ if ( empty( $webring_websites ) ) {
 		$wrapper_attributes,
 		$list_items_markup
 	);
+	// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 }


### PR DESCRIPTION
The first proof of concept of the plugin was using the `post_title` of a webring website in the queries.

This new version now uses a new post meta `_webring_website_url_sanitized`. It is automatically populated with the sanitized value of the post meta `webring_website_url` on every post save.