### PR TITLE
Add `page-attributes` support to enable to `order` field

### DIFF
--- a/lib/PostType/Website.php
+++ b/lib/PostType/Website.php
@@ -65,6 +65,7 @@ class Website {
 				'supports'              => [
 					'custom-fields',
 					'editor',
+					'page-attributes',
 					'thumbnail',
 					'title',
 				],


### PR DESCRIPTION
This shows the "order" field in the "Quick Edit" view